### PR TITLE
Codestyle & Doc Block

### DIFF
--- a/administrator/components/com_messages/views/config/tmpl/default.php
+++ b/administrator/components/com_messages/views/config/tmpl/default.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package     Messages
+ * @package     Joomla.Administrator
  * @subpackage  com_messages
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  Messages
+ * @subpackage  com_messages
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  Messages
+ * @subpackage  com_messages
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -89,7 +89,9 @@ class MessagesViewMessages extends JViewLegacy
 			'',
 			'<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
 			. JText::_('JCANCEL')
-			. '</button><button class="btn btn-success" type="button" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#modal-cog iframe\').contents().find(\'#saveBtn\').click();">'
+			. '</button>'
+			. '<button class="btn btn-success" type="button" data-dismiss="modal" aria-hidden="true"'
+			. ' onclick="jQuery(\'#modal-cog iframe\').contents().find(\'#saveBtn\').click();">'
 			. JText::_('JSAVE')
 			. '</button>'
 		);


### PR DESCRIPTION
Sorry @dgt41 It just run out of my to do list. Thanks for doing it. :+1: 

This here just fix the error to make Travis happy and change the docblock back to the origin (@subpackage  com_messages)

```
FILE: ...-cms/administrator/components/com_messages/views/messages/view.html.php
--------------------------------------------------------------------------------
FOUND 0 ERROR(S) AND 1 WARNING(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 92 | WARNING | Line exceeds 150 characters; contains 181 characters
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
```
https://travis-ci.org/joomla/joomla-cms/jobs/87563174

